### PR TITLE
refactor(assets): reorganize cover assets and update UI references

### DIFF
--- a/assets/svgs/Plus (1).svg
+++ b/assets/svgs/Plus (1).svg
@@ -1,0 +1,3 @@
+<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.71631 8L14.7163 8" stroke="#555555"/>
+</svg>

--- a/assets/svgs/Plus.svg
+++ b/assets/svgs/Plus.svg
@@ -1,0 +1,4 @@
+<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.71631 2V14" stroke="#555555"/>
+<path d="M2.71631 8L14.7163 8" stroke="#555555"/>
+</svg>

--- a/lib/core/components/text.dart
+++ b/lib/core/components/text.dart
@@ -6,13 +6,17 @@ class CustomText extends StatelessWidget {
   final double fontSize;
   final Color color;
   final double letterSpace;
+  final TextOverflow overFlow;
+  final int maxLine;
   const CustomText({
     super.key,
     required this.text,
     this.fontWeight = FontWeight.normal,
     this.fontSize = 16.0,
     this.color = Colors.white,
-     this.letterSpace = 0.0,
+    this.letterSpace = 0.0,
+    this.overFlow = TextOverflow.ellipsis,
+    this.maxLine = 1
   });
 
   @override
@@ -26,9 +30,10 @@ class CustomText extends StatelessWidget {
         fontSize: fontSize,
         color: color,
         fontFamily: 'TenorSans',
+        overflow: overFlow,
       ),
 
-      maxLines: 2,
+      maxLines: maxLine,
       textAlign: TextAlign.start,
     );
   }

--- a/lib/core/theming/colors/app_colors.dart
+++ b/lib/core/theming/colors/app_colors.dart
@@ -12,4 +12,7 @@ class AppColors {
     BlendMode.srcIn,
   );
   static const mainGrey = Color(0xffC5C5C5);
+  static const mainLightGrey = Color(0xff555555);
+  //#DD8560
+  static const mainOrange = Color(0xffDD8560);
 }

--- a/lib/core/widgets/custom_app_bar.dart
+++ b/lib/core/widgets/custom_app_bar.dart
@@ -40,6 +40,7 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
         actions: [
           SvgPicture.asset(
             'assets/svgs/Search.svg',
+            
             colorFilter: appBarWidgetsColor,
           ),
           horizantalSpace(10),

--- a/lib/core/widgets/header.dart
+++ b/lib/core/widgets/header.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:open__fashion__app/core/components/text.dart';
-import 'package:open__fashion__app/core/helpers/spacing.dart';
+import 'package:open__fashion__app/core/theming/colors/app_colors.dart';
 
 class Header extends StatelessWidget {
   final String text;
@@ -11,12 +10,13 @@ class Header extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        CustomText(text: text, letterSpace: 3,),
-        verticalSpace(20),
-        SvgPicture.asset('assets/texts/home_devider.svg', width: 160.w),
-      ],
+    return Center(
+      child: Column(
+        children: [
+          CustomText(text: text, letterSpace: 6,color: Colors.black,fontSize: 23.sp,fontWeight: FontWeight.w400),
+          Image.asset('assets/images/divider2.png', width: 125.w,color: AppColors.mainBlack,),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/chekout/ui/screens/chekout.dart
+++ b/lib/features/chekout/ui/screens/chekout.dart
@@ -1,22 +1,106 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:open__fashion__app/core/components/text.dart';
+import 'package:open__fashion__app/core/helpers/spacing.dart';
+import 'package:open__fashion__app/core/theming/colors/app_colors.dart';
 import 'package:open__fashion__app/core/widgets/custom_app_bar.dart';
 import 'package:open__fashion__app/core/widgets/header.dart';
+import 'package:open__fashion__app/features/chekout/ui/widgets/checkout_product_image.dart';
+import 'package:open__fashion__app/features/chekout/ui/widgets/products_counter.dart';
 import 'package:open__fashion__app/features/home/data/product_model.dart';
 
-class Chekout extends StatelessWidget {
+class Chekout extends StatefulWidget {
   final ProductModel product;
   const Chekout({super.key, required this.product});
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
+  State<Chekout> createState() => _ChekoutState();
+}
 
-      appBar: CustomAppBar(isBlacke: false,),
-      body: Column(
-        children: [
-          Header(text: 'Checkout'.toUpperCase() )
-        ],
+class _ChekoutState extends State<Chekout> {
+  int counterNumber = 1;
+
+  @override
+  Widget build(BuildContext context) {
+    //media query
+    MediaQueryData mediaQuery = MediaQuery.of(context);
+
+    return Scaffold(
+      appBar: CustomAppBar(isBlacke: false),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 15.0).w,
+        child: Column(
+          children: [
+            verticalSpace(25),
+            Header(text: 'Checkout'.toUpperCase()),
+            verticalSpace(20),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CheckoutProductImage(product: widget.product),
+
+                Container(
+                  padding: EdgeInsets.symmetric(horizontal: 10).w,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      verticalSpace(10),
+                      SizedBox(
+                        width: mediaQuery.size.width * 0.5,
+                        child: CustomText(
+                          text: widget.product.name.toUpperCase(),
+                          color: AppColors.mainBlack,
+                          fontSize: 14.sp,
+                          fontWeight: FontWeight.bold,
+                          letterSpace: 1.5,
+                          overFlow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      verticalSpace(5),
+                      SizedBox(
+                        width: mediaQuery.size.width * 0.5,
+
+                        child: CustomText(
+                          text: widget.product.description,
+                          fontSize: 12.sp,
+                          color: AppColors.mainLightGrey,
+                          maxLine: 2,
+                          overFlow: TextOverflow.ellipsis,
+                        ),
+                      ),
+
+                      verticalSpace(10),
+                    ProductsCounter(counterNumber: counterNumber,
+                        oOnIncrement: () {
+                          setState(() {
+                            counterNumber++;
+                          });
+                        },
+                        onDecrement: () {
+                          if (counterNumber > 1) {
+                            setState(() {
+                              counterNumber--;
+                            });
+                          }
+                        }),
+
+                        verticalSpace(10),
+                        CustomText(text: '\$${widget.product.price }',
+                          fontSize: 16.sp,
+                          color: AppColors.mainOrange,
+                          fontWeight: FontWeight.bold,
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }
 }
+

--- a/lib/features/chekout/ui/widgets/checkout_product_image.dart
+++ b/lib/features/chekout/ui/widgets/checkout_product_image.dart
@@ -2,19 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:open__fashion__app/features/home/data/product_model.dart';
 
-class HomeProductImage extends StatelessWidget {
-  final ProductModel product;
-  const HomeProductImage({super.key, required this.product});
+class CheckoutProductImage extends StatelessWidget {
+final   ProductModel product;
+  const CheckoutProductImage({super.key, required this.product});
 
   @override
   Widget build(BuildContext context) {
     return Stack(
       children: [
         Container(
-          width: 200.w,
-          height: 210.h,
+          width: 100.w,
+          height: 130.h,
           decoration: BoxDecoration(
-            
             borderRadius: BorderRadius.circular(10),
             image: DecorationImage(
               image: AssetImage(product.image),
@@ -23,8 +22,8 @@ class HomeProductImage extends StatelessWidget {
           ),
         ),
         Container(
-          width: 200.w,
-          height: 210.h,
+          width: 100.w,
+          height: 130.h,
           decoration: BoxDecoration(
             color: Colors.black.withValues(alpha: 0.15),
             borderRadius: BorderRadius.circular(10),

--- a/lib/features/chekout/ui/widgets/products_counter.dart
+++ b/lib/features/chekout/ui/widgets/products_counter.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:open__fashion__app/core/components/text.dart';
+import 'package:open__fashion__app/core/helpers/spacing.dart';
+import 'package:open__fashion__app/core/theming/colors/app_colors.dart';
+
+class ProductsCounter extends StatelessWidget {
+  final void Function()? oOnIncrement;
+  final void Function()? onDecrement;
+  final int counterNumber;
+  const ProductsCounter({
+    super.key,
+    required this.counterNumber,
+    this.oOnIncrement,
+    this.onDecrement,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        GestureDetector(
+          onTap: oOnIncrement,
+          child: ProductDecrementrIncrement(svgImage: 'assets/svgs/Plus.svg'),
+        ),
+        horizantalSpace(10),
+        CustomText(
+          text: '$counterNumber',
+          fontSize: 14.sp,
+          color: AppColors.mainBlack,
+          fontWeight: FontWeight.bold,
+        ),
+        horizantalSpace(10),
+        GestureDetector(
+          onTap: onDecrement,
+
+          child: ProductDecrementrIncrement(
+            svgImage: 'assets/svgs/Plus (1).svg',
+          ),
+        ),
+      ],
+    );
+  }
+}
+class ProductDecrementrIncrement extends StatelessWidget {
+  final String svgImage;
+  const ProductDecrementrIncrement({super.key, required this.svgImage});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(color: AppColors.mainGrey, width: 0.8.w),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(1.9).w,
+        child: SvgPicture.asset(svgImage),
+      ),
+    );
+  }
+}

--- a/lib/features/home/data/product_model.dart
+++ b/lib/features/home/data/product_model.dart
@@ -30,13 +30,13 @@ class ProductModel {
       description: 'timeless piece that never goes out of style',
     ),
     ProductModel(
-      image: 'assets/product/prod17.jpeg',
+      image: 'assets/product/prod8.jpeg',
       name: 'Black Crop Top',
       price: '500',
       description: 'designed for everyday wear with a touch of elegance',
     ),
     ProductModel(
-      image: 'assets/product/prod8.jpeg',
+      image: 'assets/product/prod17.jpeg',
       name: 'Black Combat Boots',
       price: '1200',
       description: 'perfect for special occasions with its luxurious fabric',

--- a/lib/features/home/ui/screens/home_screen.dart
+++ b/lib/features/home/ui/screens/home_screen.dart
@@ -72,9 +72,9 @@ class HomeScreen extends StatelessWidget {
                       ),
                       verticalSpace(50),
                       HomeCoversListView(),
-                      verticalSpace(40),
+                      verticalSpace(80),
                       Image.asset(
-                        'assets/cover/divider.png',
+                        'assets/images/divider.png',
                         color: Colors.white,
                       ),
                       verticalSpace(30),

--- a/lib/features/home/ui/widgets/home_display_image.dart
+++ b/lib/features/home/ui/widgets/home_display_image.dart
@@ -12,7 +12,7 @@ class HomeDisplayImage extends StatelessWidget {
 
       decoration: BoxDecoration(
         color: Colors.white,
-        borderRadius: BorderRadius.circular(30.r),
+        borderRadius: BorderRadius.circular(20.r),
       ),
       child: Image.asset('assets/images/cover1.jpeg'),
     );

--- a/lib/features/home/ui/widgets/home_product.dart
+++ b/lib/features/home/ui/widgets/home_product.dart
@@ -32,8 +32,10 @@ class HomeProduct extends StatelessWidget {
             text: product.description,
             color: Color(0xffF9F9F9),
             fontSize: 10.sp,
+            maxLine: 1,
+            overFlow: TextOverflow.ellipsis
           ),
-          verticalSpace(10),
+          verticalSpace(20),
           CustomText(text: product.name, fontWeight: FontWeight.bold),
           verticalSpace(5),
 


### PR DESCRIPTION
- Moved image assets from `assets/cover/` to `assets/images/` for better structure
- Deleted outdated covers (`cover1.jpeg`, `cover6.jpeg`)
- Added new asset `cover6.jpeg` and updated paths in related widgets and models
- Introduced `header.dart` widget and new checkout screen (`chekout.dart`)
- Updated `home_screen.dart`, `covers_model.dart`, and related components to reflect asset changes
- Refined `custom_app_bar`, `home_product`, and `home_product_image` layout
- Synced `pubspec.yaml` and test files with asset updates